### PR TITLE
Extract multiple bytes from the source in PerByte.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(byteme
-    VERSION 1.0.1
+    VERSION 1.1.0
     DESCRIPTION "No-frills byte streaming from file"
     LANGUAGES CXX)
 


### PR DESCRIPTION
This is useful when the desired number of bytes is known beforehand (e.g., when parsing structured binary formats) and we just want to get those bytes without worrying about the underlying buffers of the readers themselves.